### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1,4 +1,6 @@
 name: Continuous Delivery
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1,6 +1,4 @@
 name: Continuous Delivery
-permissions:
-  contents: read
 
 on:
   workflow_dispatch:
@@ -16,6 +14,9 @@ on:
 jobs:
   PublishOgden:
     name: Publish Ogden image to container registries
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,9 +25,9 @@ jobs:
 
   Building:
     name: Building NodeJS
-    runs-on: ubuntu-latest
     permissions:
       contents: read
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,8 @@ jobs:
   Building:
     name: Building NodeJS
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   PublishSkyra:
     name: Publish Ogden image to container registries
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -9,7 +9,7 @@ on:
         description: The SHA256 commit hash to publish
 
 jobs:
-  PublishSkyra:
+  PublishOgden:
     name: Publish Ogden image to container registries
     permissions:
       contents: read


### PR DESCRIPTION
Potential fix for [https://github.com/gw2ocs/ogden/security/code-scanning/1](https://github.com/gw2ocs/ogden/security/code-scanning/1)

To fix this problem, add a `permissions:` block specifying the least necessary permissions. For standard CI jobs that only check out code and build (without needing to upload artifacts, create releases, modify issues, etc.), the permissions can usually be limited to `contents: read`. This can be added either at the root of the workflow (to apply to all jobs), or specifically under the `Building` job (to apply only there). To address the highlighted region, we should add `permissions: contents: read` under the `Building` job (line 27 or above). No additional imports or methods are needed; simply update the YAML to include this block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
